### PR TITLE
feat(ui): added tooltip component

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -17,6 +17,7 @@ import { TrackTabs } from './tab';
 import { Table } from './table';
 import { Tag } from './tag';
 import { ToggleBox } from './toggle-box';
+import { Tooltip } from './tooltip';
 import { Typography } from './typography';
 
 export {
@@ -44,6 +45,7 @@ export {
   ToggleSwitch,
   TrackTabs,
   Typography,
+  Tooltip,
   Loader,
   ComboBox,
 };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -8,11 +8,17 @@ import {
   tooltipContentVariants,
 } from 'variants';
 
-const Tooltip: FC<TooltipProps> = ({ children, content, position = 'top', className }) => {
+const Tooltip: FC<TooltipProps> = ({
+  tooltipContent,
+  children,
+  position = 'top',
+  className,
+  ...props
+}) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <div className={tooltipWrapperVariants()}>
+    <div className={tooltipWrapperVariants()} {...props}>
       <div
         className={tooltipChildrenVariants()}
         onMouseEnter={() => setIsHovered(true)}
@@ -27,12 +33,10 @@ const Tooltip: FC<TooltipProps> = ({ children, content, position = 'top', classN
       </div>
 
       {isHovered && (
-        <div
-          className={tooltipVariants({ position, className })}
-          role="tooltip"
-          id="tooltip-content"
-        >
-          <div className={tooltipContentVariants()}>{content}</div>
+        <div className={tooltipVariants({ position, className })} role="tooltip">
+          <div id="tooltip-content" className={tooltipContentVariants()}>
+            {tooltipContent}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,43 @@
+import React, { useState, type FC } from 'react';
+
+import { TooltipProps } from 'types';
+import {
+  tooltipVariants,
+  tooltipWrapperVariants,
+  tooltipChildrenVariants,
+  tooltipContentVariants,
+} from 'variants';
+
+const Tooltip: FC<TooltipProps> = ({ children, content, position = 'top', className }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <div className={tooltipWrapperVariants()}>
+      <div
+        className={tooltipChildrenVariants()}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onFocus={() => setIsHovered(true)}
+        onBlur={() => setIsHovered(false)}
+        tabIndex={0}
+        role="tooltip"
+        aria-describedby="tooltip-content"
+      >
+        {children}
+      </div>
+
+      {isHovered && (
+        <div
+          className={tooltipVariants({ position, className })}
+          role="tooltip"
+          id="tooltip-content"
+        >
+          <div className={tooltipContentVariants()}>{content}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+Tooltip.displayName = 'Tooltip';
+export { Tooltip };

--- a/src/components/variants/index.ts
+++ b/src/components/variants/index.ts
@@ -23,8 +23,13 @@ import { tabListStyles, tabStyles } from './tab-variants';
 import { tagVariants } from './tag-variants';
 import { textareaVariants } from './text-area-variants';
 import { toggleSwitchVariants } from './toggle-switch-variants';
+import {
+  tooltipVariants,
+  tooltipWrapperVariants,
+  tooltipChildrenVariants,
+  tooltipContentVariants,
+} from './tooltip-variants';
 import { typographyVariants } from './typography-variants';
-
 export {
   alertVariants,
   avatarVariants,
@@ -53,4 +58,8 @@ export {
   textareaVariants,
   toggleSwitchVariants,
   typographyVariants,
+  tooltipVariants,
+  tooltipWrapperVariants,
+  tooltipChildrenVariants,
+  tooltipContentVariants,
 };

--- a/src/components/variants/tooltip-variants.ts
+++ b/src/components/variants/tooltip-variants.ts
@@ -1,0 +1,22 @@
+import { cva } from 'class-variance-authority';
+
+export const tooltipVariants = cva(
+  'absolute z-50 px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm transition-opacity duration-300 dark:bg-gray-700',
+  {
+    variants: {
+      position: {
+        top: 'bottom-full left-1/2 transform -translate-x-1/2 mb-2',
+        bottom: 'top-full left-1/2 transform -translate-x-1/2 mt-2',
+        start: 'right-full top-1/2 transform -translate-y-1/2 mr-2',
+        end: 'left-full top-1/2 transform -translate-y-1/2 ml-2',
+      },
+    },
+    defaultVariants: {
+      position: 'top',
+    },
+  }
+);
+
+export const tooltipWrapperVariants = cva('relative inline-block');
+export const tooltipChildrenVariants = cva('inline-block');
+export const tooltipContentVariants = cva('text-xs');

--- a/src/stories/tooltip.stories.tsx
+++ b/src/stories/tooltip.stories.tsx
@@ -1,0 +1,207 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Tooltip, Button } from 'ui-components';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'UI/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    position: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'start', 'end'],
+    },
+    content: {
+      control: { type: 'text' },
+    },
+    className: {
+      control: { type: 'text' },
+    },
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    content: 'This is a default tooltip',
+    children: <Button>Hover me</Button>,
+    position: 'top',
+  },
+};
+
+export const Positions: Story = {
+  render: () => (
+    <div className="flex flex-col items-center gap-12 p-12">
+      <div className="flex flex-row gap-16 items-center">
+        <Tooltip content="Top position tooltip" position="top">
+          <Button>Top</Button>
+        </Tooltip>
+        <Tooltip content="Bottom position tooltip" position="bottom">
+          <Button>Bottom</Button>
+        </Tooltip>
+      </div>
+      <div className="flex flex-row gap-16 items-center">
+        <Tooltip content="Start position tooltip" position="start">
+          <Button>Start</Button>
+        </Tooltip>
+        <Tooltip content="End position tooltip" position="end">
+          <Button>End</Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const StyleVariants: Story = {
+  render: () => (
+    <div className="flex flex-col items-center gap-8 p-8">
+      <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
+        <Tooltip content="Default style tooltip" position="top">
+          <Button variant="solid" color="default">
+            Default
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Primary color tooltip"
+          position="top"
+          className="bg-primary-500 border-primary-600"
+        >
+          <Button variant="solid" color="primary">
+            Primary
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Success color tooltip"
+          position="top"
+          className="bg-success-500 border-success-600"
+        >
+          <Button variant="solid" color="success">
+            Success
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Warning color tooltip"
+          position="top"
+          className="bg-warning-500 border-warning-600"
+        >
+          <Button variant="solid" color="warning">
+            Warning
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Danger color tooltip"
+          position="top"
+          className="bg-danger-500 border-danger-600"
+        >
+          <Button variant="solid" color="danger">
+            Danger
+          </Button>
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-row flex-wrap gap-6 items-center justify-center mt-6">
+        <Tooltip
+          content="Pastel success tooltip"
+          position="bottom"
+          className="bg-success-100 text-success-800 border-success-300"
+        >
+          <Button variant="pastel" color="success">
+            Pastel Success
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="Dark theme tooltip"
+          position="bottom"
+          className="bg-gray-800 text-white border-gray-700 dark:bg-gray-800"
+        >
+          <Button variant="solid" color="contrast">
+            Dark Theme
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const ContentTypes: Story = {
+  render: () => (
+    <div className="flex flex-row flex-wrap gap-6 items-center justify-center p-8">
+      <Tooltip content="Simple text tooltip">
+        <Button>Simple Text</Button>
+      </Tooltip>
+
+      <Tooltip content="This is a longer tooltip content that might wrap to multiple lines to show how the tooltip handles text overflow">
+        <Button>Long Content</Button>
+      </Tooltip>
+
+      <Tooltip
+        content={
+          <div className="space-y-2">
+            <div className=" font-bold text-white">Rich Content</div>
+            <ul className="list-disc list-inside text-white text-xs space-y-1">
+              <li>Multiple lines</li>
+              <li>Custom formatting</li>
+              <li>Structured layout</li>
+            </ul>
+          </div>
+        }
+      >
+        <Button>Rich Content</Button>
+      </Tooltip>
+
+      <Tooltip content="Tooltip with icon → ✅">
+        <Button>With Icon</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const TriggerElements: Story = {
+  render: () => (
+    <div className="flex flex-col items-center gap-8 p-8">
+      <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
+        <Tooltip content="Button tooltip">
+          <Button>Button</Button>
+        </Tooltip>
+
+        <Tooltip content="Text link tooltip">
+          <span className="text-blue-500 cursor-help underline decoration-dashed">Text Link</span>
+        </Tooltip>
+
+        <Tooltip content="Icon tooltip">
+          <div className="w-10 h-10 bg-gray-200 rounded-lg cursor-help flex items-center justify-center hover:bg-gray-300 transition-colors">
+            <span className="text-lg">ℹ️</span>
+          </div>
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
+        <Tooltip content="Disabled element tooltip">
+          <Button isDisabled={true}>Disabled Button</Button>
+        </Tooltip>
+
+        <Tooltip content="Small icon tooltip">
+          <div className="w-6 h-6 bg-primary-500 rounded-full cursor-help flex items-center justify-center">
+            <span className="text-white text-xs">i</span>
+          </div>
+        </Tooltip>
+
+        <Tooltip content="Custom styled element">
+          <div className="px-4 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg cursor-help font-medium">
+            Gradient
+          </div>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};

--- a/src/stories/tooltip.stories.tsx
+++ b/src/stories/tooltip.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    content: 'This is a default tooltip',
+    tooltipContent: 'This is a default tooltip',
     children: <Button>Hover me</Button>,
     position: 'top',
   },
@@ -38,18 +38,18 @@ export const Positions: Story = {
   render: () => (
     <div className="flex flex-col items-center gap-12 p-12">
       <div className="flex flex-row gap-16 items-center">
-        <Tooltip content="Top position tooltip" position="top">
+        <Tooltip tooltipContent="Top position tooltip" position="top">
           <Button>Top</Button>
         </Tooltip>
-        <Tooltip content="Bottom position tooltip" position="bottom">
+        <Tooltip tooltipContent="Bottom position tooltip" position="bottom">
           <Button>Bottom</Button>
         </Tooltip>
       </div>
       <div className="flex flex-row gap-16 items-center">
-        <Tooltip content="Start position tooltip" position="start">
+        <Tooltip tooltipContent="Start position tooltip" position="start">
           <Button>Start</Button>
         </Tooltip>
-        <Tooltip content="End position tooltip" position="end">
+        <Tooltip tooltipContent="End position tooltip" position="end">
           <Button>End</Button>
         </Tooltip>
       </div>
@@ -61,14 +61,14 @@ export const StyleVariants: Story = {
   render: () => (
     <div className="flex flex-col items-center gap-8 p-8">
       <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
-        <Tooltip content="Default style tooltip" position="top">
+        <Tooltip tooltipContent="Default style tooltip" position="top">
           <Button variant="solid" color="default">
             Default
           </Button>
         </Tooltip>
 
         <Tooltip
-          content="Primary color tooltip"
+          tooltipContent="Primary color tooltip"
           position="top"
           className="bg-primary-500 border-primary-600"
         >
@@ -78,7 +78,7 @@ export const StyleVariants: Story = {
         </Tooltip>
 
         <Tooltip
-          content="Success color tooltip"
+          tooltipContent="Success color tooltip"
           position="top"
           className="bg-success-500 border-success-600"
         >
@@ -88,7 +88,7 @@ export const StyleVariants: Story = {
         </Tooltip>
 
         <Tooltip
-          content="Warning color tooltip"
+          tooltipContent="Warning color tooltip"
           position="top"
           className="bg-warning-500 border-warning-600"
         >
@@ -98,7 +98,7 @@ export const StyleVariants: Story = {
         </Tooltip>
 
         <Tooltip
-          content="Danger color tooltip"
+          tooltipContent="Danger color tooltip"
           position="top"
           className="bg-danger-500 border-danger-600"
         >
@@ -110,7 +110,7 @@ export const StyleVariants: Story = {
 
       <div className="flex flex-row flex-wrap gap-6 items-center justify-center mt-6">
         <Tooltip
-          content="Pastel success tooltip"
+          tooltipContent="Pastel success tooltip"
           position="bottom"
           className="bg-success-100 text-success-800 border-success-300"
         >
@@ -120,7 +120,7 @@ export const StyleVariants: Story = {
         </Tooltip>
 
         <Tooltip
-          content="Dark theme tooltip"
+          tooltipContent="Dark theme tooltip"
           position="bottom"
           className="bg-gray-800 text-white border-gray-700 dark:bg-gray-800"
         >
@@ -136,16 +136,16 @@ export const StyleVariants: Story = {
 export const ContentTypes: Story = {
   render: () => (
     <div className="flex flex-row flex-wrap gap-6 items-center justify-center p-8">
-      <Tooltip content="Simple text tooltip">
+      <Tooltip tooltipContent="Simple text tooltip">
         <Button>Simple Text</Button>
       </Tooltip>
 
-      <Tooltip content="This is a longer tooltip content that might wrap to multiple lines to show how the tooltip handles text overflow">
+      <Tooltip tooltipContent="This is a longer tooltip content that might wrap to multiple lines to show how the tooltip handles text overflow">
         <Button>Long Content</Button>
       </Tooltip>
 
       <Tooltip
-        content={
+        tooltipContent={
           <div className="space-y-2">
             <div className=" font-bold text-white">Rich Content</div>
             <ul className="list-disc list-inside text-white text-xs space-y-1">
@@ -159,7 +159,7 @@ export const ContentTypes: Story = {
         <Button>Rich Content</Button>
       </Tooltip>
 
-      <Tooltip content="Tooltip with icon → ✅">
+      <Tooltip tooltipContent="Tooltip with icon → ✅">
         <Button>With Icon</Button>
       </Tooltip>
     </div>
@@ -170,15 +170,15 @@ export const TriggerElements: Story = {
   render: () => (
     <div className="flex flex-col items-center gap-8 p-8">
       <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
-        <Tooltip content="Button tooltip">
+        <Tooltip tooltipContent="Button tooltip">
           <Button>Button</Button>
         </Tooltip>
 
-        <Tooltip content="Text link tooltip">
+        <Tooltip tooltipContent="Text link tooltip">
           <span className="text-blue-500 cursor-help underline decoration-dashed">Text Link</span>
         </Tooltip>
 
-        <Tooltip content="Icon tooltip">
+        <Tooltip tooltipContent="Icon tooltip">
           <div className="w-10 h-10 bg-gray-200 rounded-lg cursor-help flex items-center justify-center hover:bg-gray-300 transition-colors">
             <span className="text-lg">ℹ️</span>
           </div>
@@ -186,17 +186,17 @@ export const TriggerElements: Story = {
       </div>
 
       <div className="flex flex-row flex-wrap gap-6 items-center justify-center">
-        <Tooltip content="Disabled element tooltip">
+        <Tooltip tooltipContent="Disabled element tooltip">
           <Button isDisabled={true}>Disabled Button</Button>
         </Tooltip>
 
-        <Tooltip content="Small icon tooltip">
+        <Tooltip tooltipContent="Small icon tooltip">
           <div className="w-6 h-6 bg-primary-500 rounded-full cursor-help flex items-center justify-center">
             <span className="text-white text-xs">i</span>
           </div>
         </Tooltip>
 
-        <Tooltip content="Custom styled element">
+        <Tooltip tooltipContent="Custom styled element">
           <div className="px-4 py-2 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-lg cursor-help font-medium">
             Gradient
           </div>

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -226,11 +226,10 @@ export interface TextAreaProps
   shape?: Shape;
 }
 
-export interface TooltipProps {
-  content: string | React.ReactNode;
+export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  tooltipContent: string | React.ReactNode;
   children: React.ReactNode;
   position?: 'top' | 'bottom' | 'start' | 'end';
-  className?: string;
 }
 
 export interface LoaderProps

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -226,6 +226,13 @@ export interface TextAreaProps
   shape?: Shape;
 }
 
+export interface TooltipProps {
+  content: string | React.ReactNode;
+  children: React.ReactNode;
+  position?: 'top' | 'bottom' | 'start' | 'end';
+  className?: string;
+}
+
 export interface LoaderProps
   extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'>,
     VariantProps<typeof loaderVariants> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ import {
   ToggleBoxProps,
   ToggleSwitchProps,
   TrackTabsProps,
+  TooltipProps,
   Variant,
 } from './components';
 import { Sizes } from './theme';
@@ -47,5 +48,6 @@ export type {
   ToggleBoxProps,
   ToggleSwitchProps,
   TrackTabsProps,
+  TooltipProps,
   Variant,
 };


### PR DESCRIPTION
PR Title: Add Tooltip component

Summary: Accessible Tooltip with hover/focus triggers and multiple positioning options

Files:
- `tooltip.tsx`
- `tooltip-variants.ts` 
- `tooltip.stories.tsx`

Features:
- Hover/focus triggers, Escape key dismiss
- `top`/`bottom`/`start`/`end` positioning
- `role="tooltip"`, proper ARIA labels
- String or React node content support

API:
- `content: string | ReactNode`
- `position?: 'top' | 'bottom' | 'start' | 'end'`
- `children: ReactNode`
- `className?: string`

Tests: Comprehensive Storybook stories with all variants and interaction demos

How to verify:
- Open Storybook → UI/Tooltip
- Hover over each example
- Test keyboard navigation (Tab, Escape)
- Verify all positions work correctly

Checklist: component, variants, stories, accessibility, documentation